### PR TITLE
Fix documentation to point out whether polygons/triangles should be clockwise/anticlockwise

### DIFF
--- a/src/Earclipper/EarClipping.hs
+++ b/src/Earclipper/EarClipping.hs
@@ -10,18 +10,27 @@ module Earclipper.EarClipping
 
 import Data.List (any, length)
 
--- | Triangulate given polygon and return a list of triangles.  The given
--- polygon's start point end end point has to be equal.  The first point is
--- removed before triangulation.  Use the triangulate function if you want to
--- supply a polygon directly without modification.
+-- | Triangulate given polygon and return a list of triangles.  
+-- The polygon must be given anticlockwise.  
+-- The given polygon's start point and end point have to be equal.
+-- The first point is removed before triangulation.
+-- Use the triangulate function if you want to supply a polygon directly without modification.  
+-- usage example:  
+--
+-- > toTriangle [(1,-1), (1,1),(-1,1),(-1,-1),(1,-1)]
+-- > [[(1.0,1.0),(-1.0,1.0),(-1.0,-1.0)],[(1.0,1.0),(-1.0,-1.0),(1.0,-1.0)]]
 toTriangle :: [(Double, Double)] -> [[(Double, Double)]]
 toTriangle [] = []
 toTriangle (_:bounds) =
   triangulate bounds
 
 -- | Triangulate given polygon and return a list of triangles.
--- It is assumed that the given polygon's end point is the start point
--- and that the first point in the list is not the start point.
+-- It is assumed that the given polygon's points are given anticlockwise.
+-- First and last point in the list don't need to be identical.  
+-- usage example:
+--
+-- > triangulate [(1,1),(-1,1),(-1,-1),(1,-1)]
+-- > [[(1.0,1.0),(-1.0,1.0),(-1.0,-1.0)],[(1.0,1.0),(-1.0,-1.0),(1.0,-1.0)]]
 triangulate :: [(Double, Double)] -> [[(Double, Double)]]
 triangulate =
   triangulateEar 0
@@ -42,6 +51,12 @@ triangulateEar lastear (a:x:c:xs)
         size = 3 + length xs
 
 -- | Check if given point is in given triangle.
+--   Triangle is assumed to be given clockwise.  
+--   examples:
+--
+-- > pointInTriangle [(0,0), (0,1), (1,0)] (0.1,0.1) = True
+-- > pointInTriangle [(0,0), (1,0), (0,1)] (0.1,0.1) = False
+-- > pointInTriangle [(0,0), (0,1), (1,0)] (0,0) = False
 pointInTriangle :: [(Double, Double)] -> (Double, Double) -> Bool
 pointInTriangle [(ax, ay), (bx, by), (cx, cy)] (px, py) 
   | b0 == 0 = False
@@ -52,12 +67,20 @@ pointInTriangle [(ax, ay), (bx, by), (cx, cy)] (px, py)
         b3 = 1.0 - b1 - b2
 pointInTriangle _ _ = False
 
--- | Check if any given point in list is in the given triangle.
+-- | Check if any given point in list is in the given triangle.  
+--   E.g.  
+--
+-- > isAnyPointInTriangle [(0,0), (0,1), (1,0)] [(0.1,0.1), (0.2,0.2)] = True
 isAnyPointInTriangle :: [(Double, Double)] -> [(Double, Double)] -> Bool
 isAnyPointInTriangle triangle =
   any (pointInTriangle triangle)
 
 -- | Check if given points are convex.
+--   Points need to be given clockwise, e.g.
+--
+-- > isConvex (0,0) (0,1) (1,0) = False
+-- > isConvex (0,0) (1,0) (0,1) = True
+--
 isConvex :: (Double, Double) -> (Double, Double) -> (Double, Double) -> Bool
 isConvex (p1x, p1y) (px, py) (p2x, p2y)  =
   l < 0


### PR DESCRIPTION
improves documentation by explicitly pointing out whether polygons/triangles should be clockwise/anticlockwise.